### PR TITLE
Add link from 'nodejs' to 'node' if it's missing

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -10,3 +10,13 @@
 - name: Install nodejs
   apt:
     pkg: nodejs={{nodejs_version}}*
+
+# Latest packages doesn't have 'node' executable anymore
+# It were renamed to 'nodejs'. Add link to support old
+# cookbooks which use the legacy 'node' command.
+- stat: path=/usr/bin/node
+  register: node_bin
+
+- name: Add legacy node link
+  file: src=/usr/bin/nodejs dest=/usr/bin/node state=link
+  when: not node_bin.stat.exists


### PR DESCRIPTION
Latest version of installation don't have '/usr/bin/node' executable
anymore. It were renamed to 'nodejs'. To support legacy playbooks
add link from 'nodejs' to 'node'.