### PR TITLE
Missing make install when installing from source

### DIFF
--- a/tasks/install.src.yml
+++ b/tasks/install.src.yml
@@ -11,4 +11,4 @@
 
 - name: Build nodejs
   shell: >
-    cd {{nodejs_home}}/src/node-v{{nodejs_version}} && ./configure && make -j `nproc`
+    cd {{nodejs_home}}/src/node-v{{nodejs_version}} && ./configure && make -j `nproc` && make install


### PR DESCRIPTION
I was trying to install node from source I found that the last installation step was missing, the source was configure but `node` and `npm` wasn't available.
```
cd {{nodejs_home}}/src/node-v{{nodejs_version}} && ./configure && make -j `nproc`
```
Then just adding `make install` fixed the issue for me and I'm sharing my solution if you wanna include it.
```
cd {{nodejs_home}}/src/node-v{{nodejs_version}} && ./configure && make -j `nproc` && make install
```

Thanks I hope this helps.