### PR TITLE
Python SNI workaround

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -4,7 +4,7 @@
   apt: name=apt-transport-https
 
 - name: Add APT key
-  apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key  id=68576280
+  apt_key: url=http://deb.nodesource.com/gpgkey/nodesource.gpg.key  id=68576280
 
 - name: Add APT repository
   apt_repository: repo="{{item}}" update_cache=yes


### PR DESCRIPTION
Python2 does not support SNI untill version 2.7.9. Ubuntu 14.04 uses 2.7.6 so no SNI available there. Also it seems that nodejs guys started using SNI recently and this role stopped working because it can't download apt repo key now.

Fix is really simple, it just tries to download key using http instead of https.