### PR TITLE
Get GPG apt key from keyserver.ubuntu.com

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 
 nodejs_enabled: yes                       # The role is enabled
-nodejs_version: 5.11.1
-nodejs_major_version: 5.x                 # This will determine the repo from nodejs.org used
+nodejs_version: 6.9.2
+nodejs_major_version: 6.x                 # This will determine the repo from nodejs.org used
 nodejs_install: pkg                       # Install nodejs from packages, sources or binary
                                           # (pkg|src|bin)
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -21,7 +21,7 @@ docker info || exit 1
 
 assert () {
     echo "ASSERT: $1"
-    execute "$@" || ( echo ${2-'Test is failed'} && exit 1 )
+    execute "$@" || ( echo ${2-'Test failed'} && exit 1 )
     echo "SUCCESS"
 }
 
@@ -41,7 +41,7 @@ suite () {
     done
 
     echo
-    
+
 }
 
 

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -4,7 +4,7 @@
   apt: name=apt-transport-https
 
 - name: Add APT key
-  apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key  id=68576280
+  apt_key: url=https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280  id=68576280
 
 - name: Add APT repository
   apt_repository: repo="{{item}}" update_cache=yes


### PR DESCRIPTION
Essentially the same fix as
https://github.com/nodesource/ansible-nodejs-role/pull/34