### PR TITLE
Install EPEL repo before nodejs

### DIFF
--- a/tasks/install.yum.yml
+++ b/tasks/install.yum.yml
@@ -1,8 +1,10 @@
 ---
 
+- name: Install EPEL
+  yum: name=epel-release
+
 - name: Install nodejs
   yum: name=nodejs
 
 - name: Install npm
   yum: name=npm
-


### PR DESCRIPTION
EPEL repo was needed to install nodejs
See: https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-a-centos-7-server#install-node-from-the-epel-repository